### PR TITLE
fix: resolve tailwindcss workspace root and migrate middleware to proxy

### DIFF
--- a/team-8/next.config.ts
+++ b/team-8/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  turbopack: {
+    root: path.resolve(__dirname),
+  },
 };
 
 export default nextConfig;

--- a/team-8/proxy.ts
+++ b/team-8/proxy.ts
@@ -1,7 +1,7 @@
 import { type NextRequest } from "next/server";
 import { updateSession } from "@/lib/supabase/middleware";
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   return await updateSession(request);
 }
 


### PR DESCRIPTION
- Set turbopack.root in next.config.ts to fix tailwindcss resolution
- Rename middleware.ts → proxy.ts (Next.js 16 requirement)
- Export proxy function instead of middleware