### PR TITLE
fix: production-safe mobile camera flow with reliable startup and rec…

### DIFF
--- a/team-8/app/student/exams/[id]/take/_features/ExamTaker.tsx
+++ b/team-8/app/student/exams/[id]/take/_features/ExamTaker.tsx
@@ -916,13 +916,13 @@ export default function ExamTaker({
         : null;
   const sebDetected = isSEBBrowser();
 
-  const { cameraStatus, videoRef } = useCameraMonitor({
+  const { cameraStatus, videoRef, retryCamera } = useCameraMonitor({
     sessionId,
     enabled: shouldRunContinuousCamera && (!REQUIRE_SEB || sebDetected),
     preferFrontCamera: true,
   });
   const shouldPinCameraPreview =
-    cameraStatus === "granted" && (!isMobileStandard || spotCheckOpen);
+    cameraStatus === "active" && (!isMobileStandard || spotCheckOpen);
 
   // Gaze warning count — only stored in state for badge display.
   // The ref inside useGazeMonitor is the authoritative counter.
@@ -949,7 +949,7 @@ export default function ExamTaker({
     enabled:
       !isSubmitting &&
       requireCamera &&
-      cameraStatus === "granted" &&
+      cameraStatus === "active" &&
       (!isMobileStandard || spotCheckOpen),
     onWarning: handleGazeWarning,
     onMaxWarnings: () => {
@@ -1193,7 +1193,7 @@ export default function ExamTaker({
 
   const runSpotCheck = useCallback(async () => {
     const video = videoRef.current;
-    if (!video || cameraStatus !== "granted") {
+    if (!video || cameraStatus !== "active") {
       setSpotCheckOpen(false);
       emitProctorEvent("spot_check_failed", { reason: "camera_unavailable" });
       return;
@@ -1671,30 +1671,9 @@ export default function ExamTaker({
     };
   }, [emitProctorEvent, isMobileSession]);
 
-  useEffect(() => {
-    if (!requireCamera) return;
-
-    const video = videoRef.current;
-    const stream = video?.srcObject;
-    if (!(stream instanceof MediaStream)) return;
-
-    const tracks = stream.getVideoTracks();
-    if (tracks.length === 0) return;
-
-    const handleTrackEnded = () => {
-      emitProctorEvent("camera_disconnected", { reason: "track_ended" }, 1000);
-    };
-
-    for (const track of tracks) {
-      track.addEventListener("ended", handleTrackEnded);
-    }
-
-    return () => {
-      for (const track of tracks) {
-        track.removeEventListener("ended", handleTrackEnded);
-      }
-    };
-  }, [emitProctorEvent, requireCamera, videoRef, cameraStatus]);
+  // Note: track-ended handling is now managed inside useCameraMonitor.
+  // It logs camera_disconnected via logProctorEvent and auto-retries up to MAX_AUTO_RETRIES.
+  // This effect is intentionally removed to avoid double-handling.
 
   useEffect(() => {
     if (!heartbeatIntervalMs) return;
@@ -2125,6 +2104,24 @@ export default function ExamTaker({
             </button>
           </div>
         )}
+        {requireCamera && (cameraStatus === "failed" || cameraStatus === "disconnected") && (
+          <div className="w-full max-w-[1090px] rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            <div className="flex items-center justify-between gap-4">
+              <span>
+                {cameraStatus === "denied"
+                  ? "Камерын зөвшөөрөл байхгүй. Браузерын тохиргооноос зөвшөөрнэ үү."
+                  : "Камер тасарсан байна. Шалгалт үргэлжлэх боловч камер ажиллахгүй байна."}
+              </span>
+              <button
+                type="button"
+                className="shrink-0 rounded-lg border border-red-300 bg-white px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-50"
+                onClick={retryCamera}
+              >
+                Камер дахин нээх
+              </button>
+            </div>
+          </div>
+        )}
         {gazeWarningCount > 0 && !isMobileStandard && (
           <div className="w-full max-w-full rounded-2xl border border-red-200 bg-red-50 px-4 py-2 text-center text-sm font-medium text-red-700 md:max-w-[1090px]">
             {gazeWarningCount < 3
@@ -2137,6 +2134,12 @@ export default function ExamTaker({
         <div className="flex w-full max-w-full flex-wrap items-center gap-2 md:max-w-[1090px]">
           {!isOnline && <Badge variant="destructive">Offline</Badge>}
           {cameraStatus === "denied" && <Badge variant="destructive">Камер хаалттай</Badge>}
+          {(cameraStatus === "failed" || cameraStatus === "disconnected") && requireCamera && (
+            <Badge variant="destructive">Камер тасарсан</Badge>
+          )}
+          {(cameraStatus === "requesting" || cameraStatus === "starting" || cameraStatus === "retrying") && requireCamera && (
+            <Badge variant="outline">Камер нээж байна...</Badge>
+          )}
           {shouldEnforceFullscreen && !fullscreenActive && <Badge variant="destructive">Fullscreen off</Badge>}
           {gazeWarningCount > 0 && !isMobileStandard && <Badge variant="destructive">Анхааруулга {gazeWarningCount}/3</Badge>}
           {tabSwitchCount > 0 && <Badge variant="destructive">{isMobileSession ? "App" : "Tab"} {tabSwitchCount}</Badge>}

--- a/team-8/app/student/exams/[id]/take/_features/PreExamCheck.tsx
+++ b/team-8/app/student/exams/[id]/take/_features/PreExamCheck.tsx
@@ -68,6 +68,8 @@ export default function PreExamCheck({
 }: Props) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
+  const cameraRetryCountRef = useRef(0);
+  const cameraRequestInFlightRef = useRef(false);
   const [internetStatus, setInternetStatus] = useState<CheckStatus>("checking");
   const [internetMessage, setInternetMessage] = useState("Сүлжээг шалгаж байна...");
   const [batteryStatus, setBatteryStatus] = useState<CheckStatus>("checking");
@@ -213,43 +215,139 @@ export default function PreExamCheck({
   }, []);
 
   useEffect(() => {
-    if (!requireCamera) {
-      return;
-    }
+    if (!requireCamera) return;
 
     let cancelled = false;
 
-    navigator.mediaDevices
-      .getUserMedia(getPreferredCameraConstraints(true))
-      .then((stream) => {
-        if (cancelled) {
-          stream.getTracks().forEach((track) => track.stop());
-          return;
+    async function startCamera(isRetry = false) {
+      if (cancelled) return;
+      if (cameraRequestInFlightRef.current) return;
+      cameraRequestInFlightRef.current = true;
+
+      if (isRetry) {
+        setCameraStatus("checking");
+        setCameraMessage("Камерыг дахин нээж байна...");
+      }
+
+      // Stop any previous stream before requesting a new one.
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach((t) => t.stop());
+        streamRef.current = null;
+      }
+      const vid = videoRef.current;
+      if (vid) vid.srcObject = null;
+
+      // Constraint waterfall: exact front → ideal front → any camera.
+      const constraintList: MediaStreamConstraints[] = [
+        { video: { facingMode: "user" }, audio: false },
+        { video: { facingMode: { ideal: "user" } }, audio: false },
+        { video: true, audio: false },
+      ];
+
+      let stream: MediaStream | null = null;
+      let lastErr: Error | null = null;
+
+      for (const constraints of constraintList) {
+        try {
+          stream = await navigator.mediaDevices.getUserMedia(constraints);
+          break;
+        } catch (err) {
+          lastErr = err as Error;
+          if (
+            (err as Error).name === "NotAllowedError" ||
+            (err as Error).name === "PermissionDeniedError"
+          ) {
+            break;
+          }
         }
-        streamRef.current = stream;
-        if (videoRef.current) {
-          videoRef.current.srcObject = stream;
-        }
+      }
+
+      cameraRequestInFlightRef.current = false;
+      if (cancelled) {
+        stream?.getTracks().forEach((t) => t.stop());
+        return;
+      }
+
+      if (!stream) {
+        const isPermission =
+          lastErr?.name === "NotAllowedError" ||
+          lastErr?.name === "PermissionDeniedError";
+        setCameraStatus("error");
+        setCameraMessage(
+          isPermission
+            ? "Камерын зөвшөөрөл өгөөгүй байна. Браузерын тохиргооноос зөвшөөрнэ үү."
+            : "Камерийг нээж чадсангүй. Бусад апп камерыг ашиглаж байгаа байж болно."
+        );
+        return;
+      }
+
+      streamRef.current = stream;
+      setCameraStatus("checking");
+      setCameraMessage("Камер нээгдсэн, дүрсийг шалгаж байна...");
+
+      // Attach to video element.
+      const video = videoRef.current;
+      if (video) {
+        video.srcObject = stream;
+        void video.play().catch(() => {});
+      }
+
+      // Wait for loadedmetadata (max 8 s).
+      const metaReady = await new Promise<boolean>((resolve) => {
+        const v = videoRef.current;
+        if (!v) { resolve(false); return; }
+        if (v.readyState >= HTMLMediaElement.HAVE_METADATA) { resolve(true); return; }
+        const timer = setTimeout(() => {
+          v.removeEventListener("loadedmetadata", onMeta);
+          resolve(v.readyState >= HTMLMediaElement.HAVE_METADATA);
+        }, 8000);
+        const onMeta = () => { clearTimeout(timer); resolve(true); };
+        v.addEventListener("loadedmetadata", onMeta, { once: true });
+      });
+
+      if (cancelled) return;
+
+      if (!metaReady) {
+        setCameraStatus("error");
+        setCameraMessage("Камерын дүрс ачаалагдсангүй. Дахин оролдоно уу.");
+        return;
+      }
+
+      // Short grace period so the first frame can render on slow phones.
+      await new Promise<void>((resolve) => setTimeout(resolve, 400));
+      if (cancelled) return;
+
+      const v2 = videoRef.current;
+      const tracks = stream.getVideoTracks();
+      const isRendering =
+        v2 &&
+        v2.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA &&
+        v2.videoWidth > 0 &&
+        !v2.paused &&
+        tracks.length > 0 &&
+        tracks[0].readyState === "live";
+
+      if (isRendering) {
         setCameraStatus("ok");
         setCameraMessage("Камер бэлэн байна.");
-      })
-      .catch((cameraError: DOMException) => {
-        if (cancelled) return;
+        cameraRetryCountRef.current = 0;
+      } else {
         setCameraStatus("error");
-        if (cameraError?.name === "NotAllowedError") {
-          setCameraMessage("Камерын зөвшөөрөл өгөөгүй байна.");
-        } else {
-          setCameraMessage("Камерийг нээж чадсангүй.");
-        }
-      });
+        setCameraMessage("Камер нээгдсэн ч дүрс гарахгүй байна. Дахин оролдоно уу.");
+      }
+    }
+
+    void startCamera(false);
 
     return () => {
       cancelled = true;
+      cameraRequestInFlightRef.current = false;
       if (streamRef.current) {
-        streamRef.current.getTracks().forEach((track) => track.stop());
+        streamRef.current.getTracks().forEach((t) => t.stop());
         streamRef.current = null;
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [requireCamera]);
 
   useEffect(() => {
@@ -257,7 +355,14 @@ export default function PreExamCheck({
 
     const interval = window.setInterval(() => {
       const video = videoRef.current;
-      if (!video || video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
+      const stream = streamRef.current;
+      // Only run health check when video is confirmed rendering.
+      if (
+        !video ||
+        !stream ||
+        video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA ||
+        video.videoWidth === 0
+      ) {
         return;
       }
 
@@ -267,7 +372,7 @@ export default function PreExamCheck({
         if (score < 30) {
           setCameraStatus("warning");
           setCameraMessage("Орчны гэрэл бага байна. Илүү гэрэлтэй газар сууна уу.");
-        } else if (score >= 30) {
+        } else {
           setCameraStatus("ok");
           setCameraMessage("Камер бэлэн байна.");
         }
@@ -387,6 +492,100 @@ export default function PreExamCheck({
     return () =>
       document.removeEventListener("fullscreenchange", handleFullscreenChange);
   }, [requireFullscreen, shouldEnforceFullscreen]);
+
+  function handleCameraRetry() {
+    if (cameraRequestInFlightRef.current) return;
+    cameraRetryCountRef.current += 1;
+    cameraRequestInFlightRef.current = true;
+
+    // Stop any existing stream.
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    }
+    const vid = videoRef.current;
+    if (vid) vid.srcObject = null;
+
+    setCameraStatus("checking");
+    setCameraMessage("Камерыг дахин нээж байна...");
+    setBrightnessScore(null);
+
+    const constraintList: MediaStreamConstraints[] = [
+      { video: { facingMode: "user" }, audio: false },
+      { video: { facingMode: { ideal: "user" } }, audio: false },
+      { video: true, audio: false },
+    ];
+
+    async function attempt() {
+      let stream: MediaStream | null = null;
+      let lastErr: Error | null = null;
+
+      for (const constraints of constraintList) {
+        try {
+          stream = await navigator.mediaDevices.getUserMedia(constraints);
+          break;
+        } catch (err) {
+          lastErr = err as Error;
+          if (
+            (err as Error).name === "NotAllowedError" ||
+            (err as Error).name === "PermissionDeniedError"
+          ) break;
+        }
+      }
+
+      cameraRequestInFlightRef.current = false;
+      if (!stream) {
+        const isPerm =
+          lastErr?.name === "NotAllowedError" ||
+          lastErr?.name === "PermissionDeniedError";
+        setCameraStatus("error");
+        setCameraMessage(
+          isPerm
+            ? "Камерын зөвшөөрөл байхгүй байна. Браузерын тохиргооноос зөвшөөрнэ үү."
+            : "Камерийг нээж чадсангүй. Дахин оролдоно уу."
+        );
+        return;
+      }
+
+      streamRef.current = stream;
+      const video = videoRef.current;
+      if (video) {
+        video.srcObject = stream;
+        void video.play().catch(() => {});
+      }
+
+      // Wait for metadata.
+      await new Promise<void>((resolve) => {
+        const v = videoRef.current;
+        if (!v || v.readyState >= HTMLMediaElement.HAVE_METADATA) {
+          resolve(); return;
+        }
+        const timer = setTimeout(resolve, 8000);
+        v.addEventListener("loadedmetadata", () => { clearTimeout(timer); resolve(); }, { once: true });
+      });
+
+      await new Promise<void>((resolve) => setTimeout(resolve, 400));
+
+      const v2 = videoRef.current;
+      const tracks2 = stream.getVideoTracks();
+      if (
+        v2 &&
+        v2.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA &&
+        v2.videoWidth > 0 &&
+        !v2.paused &&
+        tracks2.length > 0 &&
+        tracks2[0].readyState === "live"
+      ) {
+        setCameraStatus("ok");
+        setCameraMessage("Камер бэлэн байна.");
+      } else {
+        setCameraStatus("error");
+        setCameraMessage("Камер нээгдсэн ч дүрс гарахгүй байна. Дахин оролдоно уу.");
+      }
+    }
+
+    void attempt();
+  }
 
   async function ensureFullscreen() {
     if (!shouldEnforceFullscreen || document.fullscreenElement) {
@@ -542,30 +741,45 @@ export default function PreExamCheck({
             </div>
           </div>
 
-          <div className="flex items-center justify-between rounded-[16px] border border-[#BDBDBD] bg-white px-6 py-4 shadow-sm">
-            <div className="flex items-center gap-5">
-              <div className="flex h-8 w-8 items-center justify-center rounded-md">
-                <Camera className="h-7 w-7 text-black" />
+          <div className="rounded-[16px] border border-[#BDBDBD] bg-white px-6 py-4 shadow-sm">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-5">
+                <div className="flex h-8 w-8 items-center justify-center rounded-md">
+                  <Camera className="h-7 w-7 text-black" />
+                </div>
+                <div className="space-y-1">
+                  <p className="text-base font-medium leading-[120%] text-black">Камер</p>
+                  <p className="text-sm leading-[120%] text-[#6B6B6B]">
+                    {cameraMessage}
+                  </p>
+                </div>
               </div>
-              <div className="space-y-1">
-                <p className="text-base font-medium leading-[120%] text-black">Камер</p>
-                <p className="text-sm leading-[120%] text-[#6B6B6B]">
-                  {brightnessScore !== null
-                    ? `${cameraMessage}${cameraMessage.endsWith(".") ? "" : "."}`
-                    : cameraMessage}
-                </p>
+              <div className="flex flex-col items-center gap-0.5">
+                {cameraStatus === "checking" ? (
+                  <Loader2 className="h-6 w-6 animate-spin text-[#6B6B6B]" />
+                ) : cameraStatus === "error" ? (
+                  <XCircle className="h-6 w-6 text-[#E05252]" />
+                ) : (
+                  <CheckCircle2 className="h-6 w-6 text-[#6BBF7A]" />
+                )}
+                <span className={`text-[12px] leading-[120%] ${cameraStatus === "error" ? "text-[#E05252]" : cameraStatus === "checking" ? "text-[#6B6B6B]" : "text-[#3B8748]"}`}>
+                  {cameraStatus === "warning" ? "Анхаар" : cameraStatus === "error" ? "Алдаа" : cameraStatus === "checking" ? "Шалгаж байна" : "Хэвийн"}
+                </span>
               </div>
             </div>
-            <div className="flex w-[43px] flex-col items-center gap-0.5">
-              {cameraStatus === "error" ? (
-                <XCircle className="h-6 w-6 text-[#E05252]" />
-              ) : (
-                <CheckCircle2 className="h-6 w-6 text-[#6BBF7A]" />
-              )}
-              <span className={`text-[12px] leading-[120%] ${cameraStatus === "error" ? "text-[#E05252]" : "text-[#3B8748]"}`}>
-                {cameraStatus === "warning" ? "Анхаар" : cameraStatus === "error" ? "Алдаа" : "Хэвийн"}
-              </span>
-            </div>
+            {cameraStatus === "error" && requireCamera && (
+              <div className="mt-3 flex justify-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8 rounded-[8px] border border-[#BDBDBD] text-xs font-medium text-black hover:bg-zinc-50"
+                  onClick={handleCameraRetry}
+                >
+                  Камер дахин нээх
+                </Button>
+              </div>
+            )}
           </div>
 
           <video
@@ -600,7 +814,7 @@ export default function PreExamCheck({
               type="button"
               variant="outline"
               className="h-10 flex-1 rounded-[8px] border border-[#BDBDBD] bg-white text-sm font-medium text-black hover:bg-zinc-50"
-              onClick={() => window.location.reload()}
+              onClick={requireCamera ? handleCameraRetry : () => window.location.reload()}
             >
               Дахин шалгах
             </Button>

--- a/team-8/hooks/useCameraMonitor.ts
+++ b/team-8/hooks/useCameraMonitor.ts
@@ -1,102 +1,466 @@
 "use client";
 
-import { useEffect, useRef, useState, type RefObject } from "react";
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
 import { logProctorEvent } from "@/lib/student/actions";
-import { getPreferredCameraConstraints } from "@/lib/proctoring-client";
 
-export type CameraStatus = "pending" | "granted" | "denied" | "unavailable";
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Camera lifecycle states — ordered roughly by progression.
+ *
+ * idle         — camera disabled (enabled=false)
+ * requesting   — getUserMedia() is in flight, waiting for permission dialog
+ * starting     — stream obtained, attaching to video element, waiting for metadata
+ * active       — verified: video element has real dimensions and is playing frames
+ * denied       — user denied camera permission
+ * failed       — non-permission error OR video never rendered frames after attach
+ * disconnected — stream was active but track ended or health check detected freeze
+ * retrying     — retry getUserMedia in progress
+ * unavailable  — MediaDevices API not present in this browser
+ */
+export type CameraStatus =
+  | "idle"
+  | "requesting"
+  | "starting"
+  | "active"
+  | "denied"
+  | "failed"
+  | "disconnected"
+  | "retrying"
+  | "unavailable";
+
+export interface UseCameraMonitorResult {
+  cameraStatus: CameraStatus;
+  /** Attach to the <video> element that should display the feed. */
+  videoRef: RefObject<HTMLVideoElement | null>;
+  /** Manually trigger a full camera restart. Safe to call when status is failed/disconnected. */
+  retryCamera: () => void;
+}
 
 interface UseCameraMonitorOptions {
   sessionId: string;
-  /** Set to false to skip camera entirely (e.g. SEB not detected when required). */
+  /** Set to false to disable camera entirely. */
   enabled?: boolean;
   preferFrontCamera?: boolean;
 }
 
-export interface UseCameraMonitorResult {
-  cameraStatus: CameraStatus;
-  /** Attach to a <video> element to get the live feed (useful for Phase 2 gaze detection). */
-  videoRef: RefObject<HTMLVideoElement | null>;
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Max automatic retries (track-ended / visibility-restore).
+ *  Manual retries via retryCamera() always reset this counter. */
+const MAX_AUTO_RETRIES = 2;
+
+/** How many ms to wait for loadedmetadata before giving up. */
+const METADATA_TIMEOUT_MS = 8000;
+
+/** Grace period after metadata fires before doing the final videoWidth check. */
+const RENDER_GRACE_MS = 500;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function clog(msg: string, extra?: Record<string, unknown>) {
+  if (process.env.NODE_ENV === "production") return;
+  // eslint-disable-next-line no-console
+  console.log(`[CameraMonitor] ${msg}`, extra !== undefined ? extra : "");
 }
 
-/**
- * Requests camera permission on mount.
- * - Logs a single `camera_denied` proctor event if permission is refused.
- * - Cleans up the media stream on unmount.
- * - Never throws; safe to call even if MediaDevices API is absent.
- */
+/** True only when the video element is provably displaying live frames. */
+function verifyVideoRendering(
+  video: HTMLVideoElement | null,
+  stream: MediaStream | null
+): boolean {
+  if (!video || !stream) return false;
+  if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) return false;
+  if (video.videoWidth === 0 || video.videoHeight === 0) return false;
+  if (video.paused) return false;
+  const tracks = stream.getVideoTracks();
+  return tracks.length > 0 && tracks[0].readyState === "live";
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
 export function useCameraMonitor({
   sessionId,
   enabled = true,
   preferFrontCamera = true,
 }: UseCameraMonitorOptions): UseCameraMonitorResult {
-  const [cameraStatus, setCameraStatus] = useState<CameraStatus>("pending");
-  const videoRef = useRef<HTMLVideoElement | null>(null);
-  const streamRef = useRef<MediaStream | null>(null);
-  // Prevent logging camera_denied more than once per session mount.
-  const deniedLoggedRef = useRef(false);
   const cameraApiAvailable =
     typeof navigator !== "undefined" &&
     Boolean(navigator.mediaDevices?.getUserMedia);
-  const effectiveCameraStatus: CameraStatus =
-    !enabled || (typeof navigator !== "undefined" && !cameraApiAvailable)
-      ? "unavailable"
-      : cameraStatus;
 
-  useEffect(() => {
-    if (!enabled || !cameraApiAvailable) {
-      return;
+  const [cameraStatus, setCameraStatus] = useState<CameraStatus>(() => {
+    if (!enabled) return "idle";
+    if (!cameraApiAvailable) return "unavailable";
+    return "requesting";
+  });
+
+  // Ref mirrors state so closures inside setTimeout / event handlers always
+  // read the current value without needing to be in a dependency array.
+  const cameraStatusRef = useRef<CameraStatus>(cameraStatus);
+
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const mountedRef = useRef(true);
+  const requestInFlightRef = useRef(false);
+  const autoRetryCountRef = useRef(0);
+  const everActiveRef = useRef(false);
+  const deniedLoggedRef = useRef(false);
+
+  // startCameraRef holds the latest version of startCamera so callbacks inside
+  // setTimeout and event listeners never close over a stale function.
+  const startCameraRef = useRef<(isRetry?: boolean) => void>(() => {});
+
+  // Keep status ref in sync with state.
+  const updateStatus = useCallback((next: CameraStatus) => {
+    cameraStatusRef.current = next;
+    setCameraStatus(next);
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Stop all tracks and clear srcObject.
+  // -------------------------------------------------------------------------
+  const stopCurrentStream = useCallback(() => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
     }
+    const video = videoRef.current;
+    if (video) {
+      try { video.srcObject = null; } catch { /* ignore */ }
+    }
+  }, []);
 
-    let cancelled = false;
+  // -------------------------------------------------------------------------
+  // Core camera start — called on mount and on every retry.
+  // -------------------------------------------------------------------------
+  const startCamera = useCallback(
+    async (isRetry = false) => {
+      if (!mountedRef.current) return;
+      if (requestInFlightRef.current) return;
+      requestInFlightRef.current = true;
 
-    navigator.mediaDevices
-      .getUserMedia(getPreferredCameraConstraints(preferFrontCamera))
-      .then((stream) => {
-        if (cancelled) {
-          // Unmounted before stream arrived — release immediately.
-          stream.getTracks().forEach((t) => t.stop());
-          return;
+      clog(isRetry ? "retry started" : "requesting camera");
+      updateStatus(isRetry ? "retrying" : "requesting");
+
+      // Stop any existing stream before opening a new one.
+      stopCurrentStream();
+
+      // Constraint waterfall:
+      //   1. Exact front camera (may fail on some Android devices)
+      //   2. Ideal front camera (softer constraint, broader compat)
+      //   3. Bare minimum (any camera — last resort)
+      const constraintList: MediaStreamConstraints[] = preferFrontCamera
+        ? [
+            { video: { facingMode: "user" }, audio: false },
+            { video: { facingMode: { ideal: "user" } }, audio: false },
+            { video: true, audio: false },
+          ]
+        : [{ video: true, audio: false }];
+
+      let stream: MediaStream | null = null;
+      let lastErr: Error | null = null;
+
+      for (const constraints of constraintList) {
+        try {
+          stream = await navigator.mediaDevices.getUserMedia(constraints);
+          clog("getUserMedia succeeded", { constraints });
+          break;
+        } catch (err) {
+          lastErr = err as Error;
+          clog("getUserMedia attempt failed", {
+            name: (err as Error).name,
+            msg: (err as Error).message,
+            constraints,
+          });
+          // Permission denied — no point trying other constraints.
+          if (
+            (err as Error).name === "NotAllowedError" ||
+            (err as Error).name === "PermissionDeniedError"
+          ) {
+            break;
+          }
         }
-        streamRef.current = stream;
-        if (videoRef.current) {
-          videoRef.current.srcObject = stream;
-        }
-        setCameraStatus("granted");
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setCameraStatus("denied");
+      }
 
-        // Log once per mount — never spam.
+      requestInFlightRef.current = false;
+
+      if (!mountedRef.current) {
+        stream?.getTracks().forEach((t) => t.stop());
+        return;
+      }
+
+      if (!stream) {
+        const isPermission =
+          lastErr?.name === "NotAllowedError" ||
+          lastErr?.name === "PermissionDeniedError";
+
+        clog(isPermission ? "camera permission denied" : "camera failed", {
+          error: lastErr?.name,
+        });
+        updateStatus(isPermission ? "denied" : "failed");
+
         if (!deniedLoggedRef.current) {
           deniedLoggedRef.current = true;
           void logProctorEvent(sessionId, "camera_denied", {
-            reason: "permission_denied",
+            reason: isPermission ? "permission_denied" : "getUserMedia_failed",
+            error_name: lastErr?.name ?? "unknown",
           });
         }
+        return;
+      }
+
+      streamRef.current = stream;
+      updateStatus("starting");
+      clog("stream obtained — attaching to video element");
+
+      // Register track-ended listener for automatic recovery.
+      stream.getVideoTracks().forEach((track) => {
+        track.addEventListener("ended", () => {
+          if (!mountedRef.current) return;
+          // Guard: ignore ended events from tracks we stopped ourselves during retry.
+          if (requestInFlightRef.current) return;
+
+          clog("video track ended externally");
+          void logProctorEvent(sessionId, "camera_disconnected", {
+            reason: "track_ended",
+          });
+          updateStatus("disconnected");
+
+          if (autoRetryCountRef.current < MAX_AUTO_RETRIES) {
+            autoRetryCountRef.current += 1;
+            clog("auto-retry after track ended", {
+              attempt: autoRetryCountRef.current,
+            });
+            // Short delay — let the OS release the hardware before re-opening.
+            setTimeout(() => {
+              if (mountedRef.current) startCameraRef.current(true);
+            }, 1200);
+          }
+        });
       });
 
-    return () => {
-      cancelled = true;
-      if (streamRef.current) {
-        streamRef.current.getTracks().forEach((t) => t.stop());
-        streamRef.current = null;
+      // Attach to video element.
+      const video = videoRef.current;
+      if (video) {
+        video.srcObject = stream;
+        // Explicit play() — on some mobile browsers setting srcObject alone
+        // is not sufficient to begin rendering; play() is required.
+        void video.play().catch((e: Error) => {
+          clog("video.play() rejected", { name: e.name });
+          // Autoplay is extremely unlikely to be blocked for muted camera streams,
+          // but handle gracefully — frames may still render via autoPlay attribute.
+        });
       }
-    };
-  }, [cameraApiAvailable, sessionId, enabled, preferFrontCamera]);
+      // If videoRef.current was null (race between render and effect),
+      // the secondary-attach effect below will handle it.
 
-  // Secondary attach: if the video element mounted after getUserMedia resolved
-  // (common on iOS Safari where React may defer the ref assignment), ensure the
-  // stream is assigned to srcObject before the component renders.
+      // ------------------------------------------------------------------
+      // Wait for loadedmetadata — proves the browser decoded the stream header.
+      // ------------------------------------------------------------------
+      const metaReady = await new Promise<boolean>((resolve) => {
+        const vid = videoRef.current;
+        if (!vid) {
+          resolve(false);
+          return;
+        }
+
+        if (vid.readyState >= HTMLMediaElement.HAVE_METADATA) {
+          clog("loadedmetadata already ready");
+          resolve(true);
+          return;
+        }
+
+        const timer = setTimeout(() => {
+          vid.removeEventListener("loadedmetadata", onMeta);
+          clog("loadedmetadata timeout", {
+            readyState: vid.readyState,
+          });
+          // Accept partial readiness rather than failing immediately.
+          resolve(vid.readyState >= HTMLMediaElement.HAVE_METADATA);
+        }, METADATA_TIMEOUT_MS);
+
+        const onMeta = () => {
+          clearTimeout(timer);
+          clog("loadedmetadata fired");
+          resolve(true);
+        };
+
+        vid.addEventListener("loadedmetadata", onMeta, { once: true });
+      });
+
+      if (!mountedRef.current) {
+        stopCurrentStream();
+        return;
+      }
+
+      if (!metaReady) {
+        clog("metadata never loaded — marking failed");
+        updateStatus("failed");
+        void logProctorEvent(sessionId, "camera_denied", {
+          reason: "metadata_timeout",
+        });
+        return;
+      }
+
+      // ------------------------------------------------------------------
+      // Grace period: give a slow phone time to push the first frame through.
+      // ------------------------------------------------------------------
+      await new Promise<void>((resolve) => setTimeout(resolve, RENDER_GRACE_MS));
+
+      if (!mountedRef.current) {
+        stopCurrentStream();
+        return;
+      }
+
+      // ------------------------------------------------------------------
+      // Final validation — confirm frames are actually rendering.
+      // ------------------------------------------------------------------
+      const video2 = videoRef.current;
+      if (verifyVideoRendering(video2, streamRef.current)) {
+        everActiveRef.current = true;
+        autoRetryCountRef.current = 0;
+        updateStatus("active");
+        clog("camera active — verified rendering", {
+          videoWidth: video2?.videoWidth,
+          videoHeight: video2?.videoHeight,
+        });
+      } else {
+        // Stream attached and metadata loaded, but no frames visible.
+        // Common on some Android devices where camera hardware is momentarily busy.
+        clog("video not rendering after grace period — marking failed", {
+          readyState: video2?.readyState,
+          videoWidth: video2?.videoWidth,
+          videoHeight: video2?.videoHeight,
+          paused: video2?.paused,
+          trackState: streamRef.current?.getVideoTracks()[0]?.readyState,
+        });
+        updateStatus("failed");
+        void logProctorEvent(sessionId, "camera_denied", {
+          reason: "video_not_rendering",
+          ready_state: video2?.readyState ?? -1,
+          video_width: video2?.videoWidth ?? 0,
+          video_height: video2?.videoHeight ?? 0,
+        });
+      }
+    },
+    [preferFrontCamera, sessionId, stopCurrentStream, updateStatus]
+  );
+
+  // Keep startCameraRef pointing at the latest startCamera.
   useEffect(() => {
-    if (cameraStatus !== "granted") return;
-    const video = videoRef.current;
-    if (video && streamRef.current && video.srcObject !== streamRef.current) {
-      video.srcObject = streamRef.current;
+    startCameraRef.current = startCamera;
+  }, [startCamera]);
+
+  // -------------------------------------------------------------------------
+  // Main lifecycle effect.
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    mountedRef.current = true;
+
+    if (!enabled) {
+      updateStatus("idle");
+      return;
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    if (!cameraApiAvailable) {
+      updateStatus("unavailable");
+      return;
+    }
+
+    void startCamera(false);
+
+    return () => {
+      mountedRef.current = false;
+      requestInFlightRef.current = false;
+      stopCurrentStream();
+    };
+    // Re-run only when the fundamental options change, not on every re-render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, preferFrontCamera, cameraApiAvailable]);
+
+  // -------------------------------------------------------------------------
+  // Secondary attach — race condition guard.
+  // If videoRef wasn't mounted yet when startCamera ran, attach here.
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    if (cameraStatus !== "starting" && cameraStatus !== "active") return;
+    const video = videoRef.current;
+    if (!video || !streamRef.current) return;
+    if (video.srcObject !== streamRef.current) {
+      clog("secondary attach — videoRef was not ready during startCamera");
+      video.srcObject = streamRef.current;
+      void video.play().catch(() => {});
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cameraStatus]);
 
-  return { cameraStatus: effectiveCameraStatus, videoRef };
+  // -------------------------------------------------------------------------
+  // Visibility recovery — mobile OS may pause/kill the stream while backgrounded.
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    if (!enabled || !cameraApiAvailable) return;
+
+    const handleVisibility = () => {
+      if (document.hidden) {
+        clog("page hidden — camera stream may be suspended");
+        return;
+      }
+      clog("page visible — checking camera health");
+
+      // Re-attach srcObject if the browser cleared it while the page was hidden.
+      const video = videoRef.current;
+      if (streamRef.current && video && video.srcObject !== streamRef.current) {
+        clog("re-attaching stream after visibility restore");
+        video.srcObject = streamRef.current;
+        void video.play().catch(() => {});
+      }
+
+      const status = cameraStatusRef.current;
+      if (
+        status === "active" ||
+        status === "disconnected" ||
+        status === "starting"
+      ) {
+        const tracks = streamRef.current?.getVideoTracks() ?? [];
+        const trackLive =
+          tracks.length > 0 && tracks[0].readyState === "live";
+
+        if (!trackLive) {
+          if (autoRetryCountRef.current < MAX_AUTO_RETRIES) {
+            autoRetryCountRef.current += 1;
+            clog("auto-retry after visibility restore", {
+              attempt: autoRetryCountRef.current,
+            });
+            startCameraRef.current(true);
+          } else {
+            updateStatus("disconnected");
+          }
+        }
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () =>
+      document.removeEventListener("visibilitychange", handleVisibility);
+  }, [enabled, cameraApiAvailable, updateStatus]);
+
+  // -------------------------------------------------------------------------
+  // Manual retry — resets auto-retry counter so student always gets fresh attempts.
+  // -------------------------------------------------------------------------
+  const retryCamera = useCallback(() => {
+    if (!enabled || !cameraApiAvailable) return;
+    if (requestInFlightRef.current) return;
+    clog("manual retry triggered");
+    autoRetryCountRef.current = 0;
+    startCameraRef.current(true);
+  }, [enabled, cameraApiAvailable]);
+
+  return { cameraStatus, videoRef, retryCamera };
 }


### PR DESCRIPTION
…overy

- Rewrote useCameraMonitor: 9-state lifecycle (idle/requesting/starting/active/ denied/failed/disconnected/retrying/unavailable), constraint waterfall (exact → ideal → bare), explicit video.play(), loadedmetadata wait, videoWidth verification before marking active, track-ended auto-retry, visibilitychange recovery, manual retryCamera(), clog diagnostics
- ExamTaker: use cameraStatus==="active" everywhere (was "granted"), add retryCamera wiring, remove duplicate track-ended handler, add camera recovery banner with "Камер дахин нээх" button, add starting/retrying badge
- PreExamCheck: constraint waterfall + metadata wait + videoWidth check in startup effect, handleCameraRetry() without page reload, inline "Камер дахин нээх" button on error, Loader2 spinner during checking state, "Дахин шалгах" triggers camera retry instead of window.location.reload()